### PR TITLE
Use functools.singledispatch on Python 3.4+

### DIFF
--- a/httpolice/reports/common.py
+++ b/httpolice/reports/common.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8; -*-
 
-from singledispatch import singledispatch
 import six
 
 from httpolice import known, notice
@@ -8,6 +7,7 @@ from httpolice.header import HeaderView
 from httpolice.parse import ParseError, Symbol
 from httpolice.structure import HeaderEntry, Parametrized
 from httpolice.util.text import format_chars
+from httpolice.util.moves import singledispatch
 
 
 def resolve_reference(ctx, path):

--- a/httpolice/reports/html.py
+++ b/httpolice/reports/html.py
@@ -5,7 +5,7 @@ import pkgutil
 import dominate
 import dominate.tags as H
 from dominate.util import text as text_node
-from singledispatch import singledispatch
+
 import six
 
 from httpolice import known, message, notice, structure
@@ -16,6 +16,7 @@ from httpolice.reports.common import (expand_error, expand_piece,
                                       find_reason_phrase, resolve_reference)
 from httpolice.structure import Unavailable
 from httpolice.util.text import nicely_join, printable
+from httpolice.util.moves import singledispatch
 
 
 ###############################################################################

--- a/httpolice/reports/text.py
+++ b/httpolice/reports/text.py
@@ -2,7 +2,6 @@
 
 import codecs
 
-from singledispatch import singledispatch
 import six
 
 from httpolice import notice
@@ -10,6 +9,7 @@ from httpolice.reports.common import (expand_piece, find_reason_phrase,
                                       resolve_reference)
 from httpolice.util.text import (detypographize, ellipsize, printable,
                                  write_if_any)
+from httpolice.util.moves import singledispatch
 
 
 def text_report(exchanges, buf):

--- a/httpolice/util/moves.py
+++ b/httpolice/util/moves.py
@@ -13,3 +13,8 @@ try:        # pragma: no cover
     from urllib.parse import unquote_to_bytes
 except ImportError:                       # Python 2; pragma: no cover
     from urllib import unquote as unquote_to_bytes
+
+try:        # pragma: no cover
+    from functools import singledispatch
+except ImportError:              # Python 2 backport; pragma: no cover
+    from singledispatch import singledispatch

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     # NB: when updating these fields,
     # make sure you don't break ``tools/minimum_requires.sh``.
     install_requires=[
-        'singledispatch >= 3.4.0.3',
         'six >= 1.10.0',
         'lxml >= 4.1.0',
         'bitstring >= 3.1.4',
@@ -44,6 +43,7 @@ setup(
     extras_require={
         ':python_version == "2.7"': [
             'enum34 >= 1.1.6',
+            'singledispatch >= 3.4.0.3',
         ],
     },
 


### PR DESCRIPTION
singledispatch dependency is a backport of the Python 3.4+
implementation of PEP 443

Closes https://github.com/vfaronov/httpolice/issues/6