### PR TITLE
Make tests pass in 2034

### DIFF
--- a/test/combined_data/1109_1
+++ b/test/combined_data/1109_1
@@ -7,7 +7,7 @@ User-Agent: demo
 
 ======== BEGIN OUTBOUND STREAM ========
 HTTP/1.1 200 OK
-Date: Tue, 13 Jan 2026 18:26:56 GMT
+Date: Sun, 13 Jan 2999 18:26:56 GMT
 Content-Type: text/plain
 Content-Length: 14
 

--- a/test/combined_data/1241_1
+++ b/test/combined_data/1241_1
@@ -8,7 +8,7 @@ User-Agent: demo
 ======== BEGIN OUTBOUND STREAM ========
 HTTP/1.1 200 OK
 Date: Thu, 21 Apr 2016 17:37:39 GMT
-Age: 157680000
+Age: 15768000000
 Content-Type: text/plain
 Cache-Control: no-cache, no-store, must-revalidate
 Content-Length: 14


### PR DESCRIPTION
Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +15 years, because that is how long I expect some software will be used in some places.